### PR TITLE
MCS-2015 Reduce max concurrent documents tasks to 3

### DIFF
--- a/queue.yaml
+++ b/queue.yaml
@@ -6,7 +6,7 @@ queue:
     - name: documents
       rate: 10/s
       bucket_size: 200
-      max_concurrent_requests: 5
+      max_concurrent_requests: 3
 
     - name: mangopay-payouts
       rate: 10/s


### PR DESCRIPTION
This is just interim solution in my opinion. In case we will have large orders these tasks will fail. Further redesign for scalability will be needed. 