### PR TITLE
MCS-2210 Handle missing company name in document seller or buyer

### DIFF
--- a/documents/models.py
+++ b/documents/models.py
@@ -204,11 +204,11 @@ class Document(OrderCalculatorMixin, BaseAbstractModel):
 
     @property
     def seller_company_name(self):
-        return self.seller["company_name"]
+        return self.seller.get("company_name")
 
     @property
     def buyer_company_name(self):
-        return self.buyer["company_name"]
+        return self.buyer.get("company_name")
 
     @property
     def is_invoice(self):


### PR DESCRIPTION
May happen for old orders.