### PR TITLE
MCS-2264 Fix bug in calculation when sorting items to calculate vat

### DIFF
--- a/core/calculators/order_calculator.py
+++ b/core/calculators/order_calculator.py
@@ -34,7 +34,7 @@ class OrderCalculatorMixin:
     @staticmethod
     def calculate_gross_value_of_items(calc_items):
         items_values = [item.value for item in calc_items]
-        items_values = sorted(items_values, key=lambda item: item.vat)
+        items_values = sorted(items_values, key=lambda item: item.vat_rate)
         gross = Decimal("0")
         for vat_rate, lines_by_vat_rate in itertools.groupby(
             items_values, lambda item_value: item_value.vat_rate

--- a/core/calculators/tests/test_order_calculator.py
+++ b/core/calculators/tests/test_order_calculator.py
@@ -35,3 +35,21 @@ def test_total_calculation_error():
         gross += OrderCalculatorMixin.calculate_gross_value_of_items(items)
 
     assert float(gross) == float(Decimal("37.52"))
+
+
+def test_total_calculation_sort_by_vat_rate():
+
+    items = [
+        OrderCalculatorMixin.Item(
+            vat=7, price=13.5, amount=1, count=1, seller="traidoo"
+        ),
+        OrderCalculatorMixin.Item(
+            vat=19, price=19.3, amount=1, count=1, seller="traidoo"
+        ),
+        OrderCalculatorMixin.Item(
+            vat=7, price=119.7, amount=1, count=1, seller="traidoo"
+        ),
+    ]
+
+    mixin = OrderCalculatorMixin()
+    assert mixin.calculate_gross_value_of_items(items) == Decimal("165.49")


### PR DESCRIPTION
Fixes also MCS-2259 to some extent since delivery VAT rates are different that product VAT rates.